### PR TITLE
Tweak to intro and "removing the need" sections

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -5,20 +5,17 @@ Passive event listeners are a new feature [in the DOM spec](https://dom.spec.wha
 ## The problem
 
 Smooth scrolling performance is essential to a good experience on the web, especially on touch-based devices.
-Yet in Chrome for Android we see that 80% of the touch events that block scrolling never actually prevent it.  10% of these events add more than 100ms of delay to the start of scrolling, and a catastrophic delay of at least 500ms occurs in 1% of scrolls.
-
 All modern browsers have a threaded scrolling feature to permit scrolling to run smoothly even when expensive
 JavaScript is running, but this optimization is partially defeated by the need to wait for the results of
-any `touchstart` and `touchmove` handlers, which may prevent the scroll entirely by calling [`preventDefault()`](http://www.w3.org/TR/touch-events/#the-touchstart-event)
-on the event. However, analysis indicates that the majority of touch event handlers on the web never actually
-call `preventDefault()`, so we're often blocking scrolling unneccesarily.
+any `touchstart` and `touchmove` handlers, which may prevent the scroll entirely by calling [`preventDefault()`](http://www.w3.org/TR/touch-events/#the-touchstart-event) on the event. However, analysis indicates that the majority of touch event handlers on the web never actually
+call `preventDefault()`, so browsers often block scrolling unneccesarily. For instance, in Chrome for Android 80% of the touch events that block scrolling never actually prevent it. 10% of these events add more than 100ms of delay to the start of scrolling, and a catastrophic delay of at least 500ms occurs in 1% of scrolls.
 
 Many developers are surprised to learn that [simply adding an empty touch handler to their document](http://rbyers.github.io/janky-touch-scroll.html) can have a
 significant negative impact on scroll performance.  Developers quite reasonably expect that the act of observing an event [should not have any side-effects](https://dom.spec.whatwg.org/#observing-event-listeners).
 
 The fundamental problem here is not limited to touch events. [`wheel` events](https://w3c.github.io/uievents/#events-wheelevents)
-suffer from an identical issue. However [pointer event handlers](https://w3c.github.io/pointerevents/) are
-designed to never block scrolling, and so do not suffer from this issue.  Essentially the passive event
+suffer from an identical issue. In contrast, [pointer event handlers](https://w3c.github.io/pointerevents/) are
+designed to never block scrolling unless a developer has explicitly indicated (through the use of `touch-action`) that a specific default browser action should be suppressed, and so do not suffer from this issue.  Essentially the passive event
 listener proposal brings the performance properties of pointer events to touch and wheel events.
 
 This proposal provides a way for authors to indicate at handler registration time whether the handler may call `preventDefault()` on the event (i.e. whether it needs an event that is [cancelable](https://dom.spec.whatwg.org/#dom-event-cancelable)). When no touch handlers at a particular point require a cancelable event, a user agent is free to start scrolling immediately without waiting for JavaScript.  That is, passive listeners are free from surprising performance side-effects.

--- a/explainer.md
+++ b/explainer.md
@@ -18,7 +18,7 @@ suffer from an identical issue. In contrast, [pointer event handlers](https://w3
 designed to never block scrolling unless a developer has explicitly indicated (through the use of `touch-action`) that a specific default browser action should be suppressed, and so do not suffer from this issue.  Essentially the passive event
 listener proposal brings the performance properties of pointer events to touch and wheel events.
 
-This proposal provides a way for authors to indicate at handler registration time whether the handler may call `preventDefault()` on the event (i.e. whether it needs an event that is [cancelable](https://dom.spec.whatwg.org/#dom-event-cancelable)). When no touch handlers at a particular point require a cancelable event, a user agent is free to start scrolling immediately without waiting for JavaScript.  That is, passive listeners are free from surprising performance side-effects.
+This proposal provides a way for authors to indicate at handler registration time whether the handler may call `preventDefault()` on the event (i.e. whether it needs an event that is [cancelable](https://dom.spec.whatwg.org/#dom-event-cancelable)). When no touch or wheel handlers at a particular point require a cancelable event, a user agent is free to start scrolling immediately without waiting for JavaScript.  That is, passive listeners are free from surprising performance side-effects.
 
 ## EventListenerOptions
 
@@ -76,14 +76,14 @@ Now rather than the browser having to block scrolling whenever there is any touc
 
 So **by marking a touch or wheel listener as `passive`, the developer is promising the handler won't call `preventDefault` to disable scrolling.**  This frees the browser up to respond to scrolling immediately without waiting for JavaScript, thus ensuring a reliably smooth scrolling experience for the user.
 
-## Removing the need to cancel touch events
+## Removing the need to cancel events
 
-There are scenarios where an author may intentionally want to disable scrolling by cancelling touch events. These include:
+There are scenarios where an author may intentionally want to disable scrolling by cancelling touch or wheel events. These include:
  * Panning a map
  * Full-page/full-screen games
  In these cases, the current browser behavior (which prevents scrolling optimization) is perfectly adequate, since scrolling itself is being prevented.
 
- However, in a number of common scenarios touch events don't need to block scrolling, eg:
+ However, in a number of common scenarios events don't need to block scrolling, eg:
  * User activity monitoring which just wants to know when the user was last active
  * `touchstart` handlers that hide some active UI (like tooltips)
  * `touchstart` and `touchend` handlers that style UI elements (without suppressing the `click` event).

--- a/explainer.md
+++ b/explainer.md
@@ -92,7 +92,7 @@ There are scenarios where an author may intentionally want to disable scrolling 
 There are a few more complicated scenarios where the handler only wants to suppress scrolling under certain conditions, eg:
  * Swiping horizontally to rotate a carousel, dismiss an item or reveal a drawer, while still permitting vertical scrolling.
    * In this case, use [touch-action](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) to declaratively disable scrolling along one axis without having to call `preventDefault()`.
-   * To continue to work correctly in all browsers, calls to `preventDefault` should be conditional on the lack of support for the particular `touch-action` rule being used (note that Safari 9 supports `touch-action: manipulation` but not the other values).
+   * To continue to work correctly in all browsers, calls to `preventDefault` should be conditional on the lack of support for the particular `touch-action` rule being used (note that Safari 9 currently only supports `touch-action: manipulation`).
  * Event delegation patterns where the code that adds the listener won't know if the consumer will cancel the event.
    * One option here is to do delegation separately for passive and non-passive listeners (as if they were different event types entirely).
    * It's also possible to leverage `touch-action` as above (treating Touch Events as you would [Pointer Events](https://w3c.github.io/pointerevents/).

--- a/explainer.md
+++ b/explainer.md
@@ -15,8 +15,7 @@ significant negative impact on scroll performance.  Developers quite reasonably 
 
 The fundamental problem here is not limited to touch events. [`wheel` events](https://w3c.github.io/uievents/#events-wheelevents)
 suffer from an identical issue. In contrast, [pointer event handlers](https://w3c.github.io/pointerevents/) are
-designed to never block scrolling unless a developer has explicitly indicated (through the use of `touch-action`) that a specific default browser action should be suppressed, and so do not suffer from this issue.  Essentially the passive event
-listener proposal brings the performance properties of pointer events to touch and wheel events.
+designed to never delay scrolling (though developers can declaratively suppress scrolling altogether with the `touch-action` CSS property), so do not suffer from this issue. Essentially the passive event listener proposal brings the performance properties of pointer events to touch and wheel events.
 
 This proposal provides a way for authors to indicate at handler registration time whether the handler may call `preventDefault()` on the event (i.e. whether it needs an event that is [cancelable](https://dom.spec.whatwg.org/#dom-event-cancelable)). When no touch or wheel handlers at a particular point require a cancelable event, a user agent is free to start scrolling immediately without waiting for JavaScript.  That is, passive listeners are free from surprising performance side-effects.
 
@@ -79,7 +78,7 @@ So **by marking a touch or wheel listener as `passive`, the developer is promisi
 ## Removing the need to cancel events
 
 There are scenarios where an author may intentionally want to disable scrolling by cancelling touch or wheel events. These include:
- * Panning a map
+ * Panning and zooming a map
  * Full-page/full-screen games
  In these cases, the current browser behavior (which prevents scrolling optimization) is perfectly adequate, since scrolling itself is being prevented.
 
@@ -93,6 +92,7 @@ There are a few more complicated scenarios where the handler only wants to suppr
  * Swiping horizontally to rotate a carousel, dismiss an item or reveal a drawer, while still permitting vertical scrolling.
    * In this case, use [touch-action](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) to declaratively disable scrolling along one axis without having to call `preventDefault()`.
    * To continue to work correctly in all browsers, calls to `preventDefault` should be conditional on the lack of support for the particular `touch-action` rule being used (note that Safari 9 currently only supports `touch-action: manipulation`).
+ * A UI element (like YouTube's volume slider) which slides on horizontal wheel events without changing the scrolling behavior on vertical wheel events. Since there is no equivalent of "touch-action" for wheel events, this case can only be implemented with non-passive wheel listeners.
  * Event delegation patterns where the code that adds the listener won't know if the consumer will cancel the event.
    * One option here is to do delegation separately for passive and non-passive listeners (as if they were different event types entirely).
    * It's also possible to leverage `touch-action` as above (treating Touch Events as you would [Pointer Events](https://w3c.github.io/pointerevents/).

--- a/explainer.md
+++ b/explainer.md
@@ -7,7 +7,7 @@ Passive event listeners are a new feature [in the DOM spec](https://dom.spec.wha
 Smooth scrolling performance is essential to a good experience on the web, especially on touch-based devices.
 All modern browsers have a threaded scrolling feature to permit scrolling to run smoothly even when expensive
 JavaScript is running, but this optimization is partially defeated by the need to wait for the results of
-any `touchstart` and `touchmove` handlers, which may prevent the scroll entirely by calling [`preventDefault()`](http://www.w3.org/TR/touch-events/#the-touchstart-event) on the event. However, analysis indicates that the majority of touch event handlers on the web never actually
+any `touchstart` and `touchmove` handlers, which may prevent the scroll entirely by calling [`preventDefault()`](http://www.w3.org/TR/touch-events/#the-touchstart-event) on the event. While there are particular scenarios where an author may indeed want to prevent scrolling, analysis indicates that the majority of touch event handlers on the web never actually
 call `preventDefault()`, so browsers often block scrolling unneccesarily. For instance, in Chrome for Android 80% of the touch events that block scrolling never actually prevent it. 10% of these events add more than 100ms of delay to the start of scrolling, and a catastrophic delay of at least 500ms occurs in 1% of scrolls.
 
 Many developers are surprised to learn that [simply adding an empty touch handler to their document](http://rbyers.github.io/janky-touch-scroll.html) can have a
@@ -78,16 +78,18 @@ So **by marking a touch or wheel listener as `passive`, the developer is promisi
 
 ## Removing the need to cancel touch events
 
-In general touch listeners should always be `passive` unless you know they need to block scrolling.  In a number of common scenarios the `passive` option can be added (with appropriate feature detection) without any other changes, eg:
+There are scenarios where an author may intentionally want to disable scrolling by cancelling touch events. These include:
+ * Panning a map
+ * Full-page/full-screen games
+ In these cases, the current browser behavior (which prevents scrolling optimization) is perfectly adequate, since scrolling itself is being prevented.
+
+ However, in a number of common scenarios touch events don't need to block scrolling, eg:
  * User activity monitoring which just wants to know when the user was last active
  * `touchstart` handlers that hide some active UI (like tooltips)
  * `touchstart` and `touchend` handlers that style UI elements (without suppressing the `click` event).
+ For these scenarios, the `passive` option can be added (with appropriate feature detection) without any other code changes, resulting in a significantly smoother scrolling experience.
 
-And of course there are scenarios where there is no need to use a `passive` listener because the listener intentionally disables scrolling in all cases, eg:
- * Panning a map
- * Full-page games
-
-But there are a few more complicated scenarios where the handler really wants to suppress scrolling some cases but not in others.  eg:
+There are a few more complicated scenarios where the handler only wants to suppress scrolling under certain conditions, eg:
  * Swiping horizontally to rotate a carousel, dismiss an item or reveal a drawer, while still permitting vertical scrolling.
    * In this case, use [touch-action](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) to declaratively disable scrolling along one axis without having to call `preventDefault()`.
    * To continue to work correctly in all browsers, calls to `preventDefault` should be conditional on the lack of support for the particular `touch-action` rule being used (note that Safari 9 supports `touch-action: manipulation` but not the other values).


### PR DESCRIPTION
Fairly subjective reordering of certain parts of the problem statement/intro and the "removing the need" sections to make them flow a bit more logically, with a few additions/clarifications.

Also fixed a few instances where the prose focused exclusively on touch, rather than touch AND wheel
