### PR TITLE
fix(polyfill): needsWrapping should init to false

### DIFF
--- a/EventListenerOptions.polyfill.js
+++ b/EventListenerOptions.polyfill.js
@@ -19,7 +19,7 @@
     var super_prevent_default = Event.prototype.preventDefault;
 
     function parseOptions(type, listener, options, action) {
-      var needsWrapping = true;
+      var needsWrapping = false;
       var useCapture = false;
       var passive = false;
       var fieldId;


### PR DESCRIPTION
I think needsWrapping needs to init to false, otherwise it will always be wrapped (as no other condition in the function seems to cause it to ever become false?).
